### PR TITLE
feat: add secure dashboard runtime config and Kalshi time recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ TWILIO_AUTH_TOKEN=
 TWILIO_WHATSAPP_FROM=whatsapp:+14155238886
 TWILIO_WHATSAPP_TO=whatsapp:+1XXXXXXXXXX
 
+# Monitor API auth (recommended if dashboard is exposed publicly)
+# Leave blank to disable auth on /api/dashboard
+MONITOR_API_TOKEN=
+
+# Dashboard build/runtime config
+# For local dev, leave DASHBOARD_API_BASE_URL blank and rely on the Angular proxy.
+# For Netlify/static hosting, point this to your public monitor API base URL.
+DASHBOARD_API_BASE_URL=
+DASHBOARD_API_TOKEN=
+
 # State
 STATE_FILE=./data/state.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dashboard/node_modules/
 dashboard/dist/
 dashboard/.angular/
 .openclaw/
+
+dashboard/public/runtime-config.js

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -2,9 +2,12 @@
   "name": "dashboard",
   "version": "0.0.0",
   "scripts": {
+    "prestart": "node scripts/write-runtime-config.cjs",
     "ng": "ng",
+    "prebuild": "node scripts/write-runtime-config.cjs",
     "start": "ng serve",
     "build": "ng build",
+    "prewatch": "node scripts/write-runtime-config.cjs",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/dashboard/scripts/write-runtime-config.cjs
+++ b/dashboard/scripts/write-runtime-config.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const outputPath = path.resolve(__dirname, '..', 'public', 'runtime-config.js');
+const apiBaseUrl = String(process.env.DASHBOARD_API_BASE_URL || '').trim();
+const apiToken = String(process.env.DASHBOARD_API_TOKEN || '').trim();
+
+const payload = {
+  apiBaseUrl,
+  apiToken,
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(
+  outputPath,
+  `window.__DASHBOARD_RUNTIME__ = ${JSON.stringify(payload, null, 2)};\n`,
+  'utf8',
+);
+
+console.log(`Wrote dashboard runtime config to ${outputPath}`);

--- a/dashboard/src/app/app.ts
+++ b/dashboard/src/app/app.ts
@@ -13,6 +13,7 @@ import {
   Tooltip,
   type ChartConfiguration,
 } from 'chart.js';
+import { buildApiUrl, getDashboardRuntimeConfig } from './runtime-config';
 
 interface DashboardPayload {
   generatedAt: string;
@@ -329,7 +330,15 @@ export class App implements OnDestroy {
     if (!d) return [];
     return [
       { label: 'Available Balance', value: d.account.balanceUsd, format: 'usd' },
-      { label: 'Portfolio Value', value: d.account.portfolioValueUsd, format: 'usd' },
+      { label: 'Open Position Value', value: d.account.portfolioValueUsd, format: 'usd' },
+      {
+        label: 'Net Account Value',
+        value:
+          d.account.balanceUsd === null && d.account.portfolioValueUsd === null
+            ? null
+            : Number(((d.account.balanceUsd ?? 0) + (d.account.portfolioValueUsd ?? 0)).toFixed(2)),
+        format: 'usd',
+      },
       { label: 'Today PnL', value: d.account.pnlTodayUsd, format: 'usd' },
       { label: 'Realized PnL', value: d.account.pnl14dUsd, format: 'usd' },
       { label: 'Open ROI PnL', value: d.account.openUnrealizedPnlUsd, format: 'usd' },
@@ -531,7 +540,10 @@ export class App implements OnDestroy {
   }
 
   fetchDashboard(): void {
-    this.http.get<DashboardPayload>('/api/dashboard').subscribe({
+    const runtime = getDashboardRuntimeConfig();
+    const headers = runtime.apiToken ? { Authorization: `Bearer ${runtime.apiToken}` } : undefined;
+
+    this.http.get<DashboardPayload>(buildApiUrl('/api/dashboard'), { headers }).subscribe({
       next: (payload) => {
         this.data.set(payload);
         queueMicrotask(() => this.renderChart());

--- a/dashboard/src/app/runtime-config.ts
+++ b/dashboard/src/app/runtime-config.ts
@@ -1,0 +1,29 @@
+export interface DashboardRuntimeConfig {
+  apiBaseUrl: string;
+  apiToken: string;
+}
+
+declare global {
+  interface Window {
+    __DASHBOARD_RUNTIME__?: Partial<DashboardRuntimeConfig>;
+  }
+}
+
+function sanitizeBaseUrl(value: string | undefined): string {
+  return String(value || '').trim().replace(/\/+$/, '');
+}
+
+export function getDashboardRuntimeConfig(): DashboardRuntimeConfig {
+  const runtime = window.__DASHBOARD_RUNTIME__ || {};
+
+  return {
+    apiBaseUrl: sanitizeBaseUrl(runtime.apiBaseUrl),
+    apiToken: String(runtime.apiToken || '').trim(),
+  };
+}
+
+export function buildApiUrl(pathname: string): string {
+  const { apiBaseUrl } = getDashboardRuntimeConfig();
+  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return apiBaseUrl ? `${apiBaseUrl}${normalizedPath}` : normalizedPath;
+}

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <script src="runtime-config.js"></script>
 </head>
 <body>
   <app-root></app-root>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  base = "dashboard"
+  command = "npm run build"
+  publish = "dist/dashboard/browser"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,7 @@ const config = {
   twilioAuthToken: process.env.TWILIO_AUTH_TOKEN || '',
   twilioFromWhatsApp: process.env.TWILIO_WHATSAPP_FROM || '',
   twilioToWhatsApp: process.env.TWILIO_WHATSAPP_TO || '',
+  monitorApiToken: process.env.MONITOR_API_TOKEN || '',
 };
 
 config.maxYesPrice = config.explicitMaxYesPrice ?? Math.max(0.01, Math.min(0.99, config.estimatedWinProbability - config.feeBuffer));

--- a/src/kalshiClient.js
+++ b/src/kalshiClient.js
@@ -24,6 +24,24 @@ class KalshiClient {
       baseURL: this.origin,
       timeout: 15000,
     });
+    this.timeOffsetMs = 0;
+  }
+
+  currentTimestampMs() {
+    return Math.round(Date.now() + this.timeOffsetMs).toString();
+  }
+
+  syncTimeOffset(dateHeader, { log = false } = {}) {
+    const serverMs = Date.parse(String(dateHeader || ''));
+    if (!Number.isFinite(serverMs)) return false;
+    this.timeOffsetMs = serverMs - Date.now();
+    if (log) {
+      this.logger.warn(
+        { timeOffsetMs: this.timeOffsetMs, serverDate: new Date(serverMs).toISOString() },
+        'Adjusted Kalshi client clock offset from server Date header',
+      );
+    }
+    return true;
   }
 
   async request(method, path, { params, data } = {}) {
@@ -37,29 +55,30 @@ class KalshiClient {
       });
     }
 
-    const ts = Date.now().toString();
     const pathWithQuery = toPathWithQuery(urlObj);
     const signPath = urlObj.pathname;
-    const signature = signRequest({
-      method,
-      path: signPath,
-      timestampMs: ts,
-      privateKey: this.privateKey,
-    });
-
-    const headers = {
-      'KALSHI-ACCESS-KEY': this.keyId,
-      'KALSHI-ACCESS-TIMESTAMP': ts,
-      'KALSHI-ACCESS-SIGNATURE': signature,
-    };
 
     const methodUpper = String(method || '').toUpperCase();
     const isRead = methodUpper === 'GET';
-    const maxAttempts = isRead ? 3 : 1;
+    const maxAttempts = isRead ? 3 : 2;
     let attempt = 0;
 
     while (attempt < maxAttempts) {
       attempt += 1;
+      const ts = this.currentTimestampMs();
+      const signature = signRequest({
+        method,
+        path: signPath,
+        timestampMs: ts,
+        privateKey: this.privateKey,
+      });
+
+      const headers = {
+        'KALSHI-ACCESS-KEY': this.keyId,
+        'KALSHI-ACCESS-TIMESTAMP': ts,
+        'KALSHI-ACCESS-SIGNATURE': signature,
+      };
+
       try {
         const response = await this.http.request({
           method,
@@ -67,15 +86,23 @@ class KalshiClient {
           data,
           headers,
         });
+        this.syncTimeOffset(response.headers?.date);
         return response.data;
       } catch (error) {
         const status = error.response?.status;
         const details = error.response?.data || error.message;
-        const retriable = isRead && (status === 429 || (status >= 500 && status < 600));
+        const errorCode = error.response?.data?.error?.code;
+        const timestampExpired = status === 401 && errorCode === 'header_timestamp_expired';
+        const adjustedClock = timestampExpired
+          ? this.syncTimeOffset(error.response?.headers?.date, { log: true })
+          : false;
+        const retriable =
+          (isRead && (status === 429 || (status >= 500 && status < 600))) ||
+          (timestampExpired && adjustedClock);
         const canRetry = retriable && attempt < maxAttempts;
 
         this.logger.error(
-          { method, path: pathWithQuery, status, details, attempt, maxAttempts },
+          { method, path: pathWithQuery, status, details, attempt, maxAttempts, timeOffsetMs: this.timeOffsetMs },
           canRetry ? 'Kalshi API request failed, retrying' : 'Kalshi API request failed',
         );
 

--- a/src/monitorServer.js
+++ b/src/monitorServer.js
@@ -36,6 +36,26 @@ let logCache = {
   parsed: [],
 };
 
+function extractBearerToken(req) {
+  const auth = String(req.headers.authorization || '');
+  if (auth.startsWith('Bearer ')) return auth.slice('Bearer '.length).trim();
+  const headerToken = String(req.headers['x-monitor-token'] || '').trim();
+  return headerToken || '';
+}
+
+function requireMonitorAuth(req, res, next) {
+  if (!config.monitorApiToken) return next();
+
+  const token = extractBearerToken(req);
+  if (token && token === config.monitorApiToken) return next();
+
+  return res.status(401).json({
+    ok: false,
+    error: 'unauthorized',
+    message: 'Valid monitor API token required',
+  });
+}
+
 function safeReadJson(filePath, fallback) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -602,7 +622,7 @@ app.get('/api/health', async (_req, res) => {
   res.json({ ok: true, ts: new Date().toISOString() });
 });
 
-app.get('/api/dashboard', async (_req, res) => {
+app.get('/api/dashboard', requireMonitorAuth, async (_req, res) => {
   const runtime = getRuntimeConfig(config);
   const actionLogs = readActionLogs();
   const { important: importantLogs, verbose: verboseLogs } = splitLogs(actionLogs);


### PR DESCRIPTION
## Summary
- add runtime-configurable dashboard API connectivity for Netlify/static hosting
- add simple token auth for the monitor API when exposing it publicly
- recover automatically from local clock skew on Kalshi-signed requests
- clarify account metrics by separating open position value from net account value

## What changed
- frontend runtime config
  - generate `runtime-config.js` during dashboard build/start
  - support `DASHBOARD_API_BASE_URL` and `DASHBOARD_API_TOKEN`
  - load dashboard API endpoint/token at runtime instead of hardcoding `/api`
- monitor API auth
  - add `MONITOR_API_TOKEN`
  - require bearer token on `/api/dashboard` when configured
- Kalshi client resilience
  - detect `header_timestamp_expired`
  - sync from server `Date` header
  - retry with a corrected timestamp
- account metric cleanup
  - rename `Portfolio Value` to `Open Position Value`
  - add `Net Account Value = balance + open position value`
- deployment support
  - add `netlify.toml`
  - ignore generated `dashboard/public/runtime-config.js`
  - document new env vars in `.env.example`

## Validation
- `npm --prefix dashboard run build`
- `node --check src/kalshiClient.js`
- `node --check src/monitorServer.js`
- `node --check src/config.js`

## Notes
- this PR intentionally excludes prior dashboard UX/log-feed work
- generated runtime config remains untracked
