### PR TITLE
fix: use Kalshi soccer feed for live competition discovery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,11 @@ const { eligibleTradeCandidate, computeDailyLossUsd } = require('./strategy');
 const { Notifier } = require('./notifier');
 const { appendAction, LOG_PATH } = require('./actionLog');
 const { getRuntimeConfig } = require('./runtimeConfig');
-const { getLiveSoccerEventData, attachLiveDataToEvents } = require('./kalshiLiveSoccer');
+const {
+  getLiveSoccerEventData,
+  attachLiveDataToEvents,
+  resolveSoccerCompetitionScope,
+} = require('./kalshiLiveSoccer');
 
 const logger = createLogger(config.logLevel);
 const notifier = new Notifier(config, logger);
@@ -228,12 +232,13 @@ async function runCycle(client) {
     return;
   }
 
-  const [{ balance }, openPositions, events, liveSoccerMap] = await Promise.all([
+  const [{ balance }, openPositions, events] = await Promise.all([
     client.getBalance(),
     client.getOpenPositions(),
     client.getOpenEventsWithMarkets(),
-    getLiveSoccerEventData(client, runtime.leagues || []),
   ]);
+  const liveCompetitionScope = await resolveSoccerCompetitionScope(client, events, runtime.leagues || [], logger);
+  const liveSoccerMap = await getLiveSoccerEventData(client, liveCompetitionScope);
   const enrichedEvents = attachLiveDataToEvents(events, liveSoccerMap);
   const openMarketTickers = (openPositions || []).map((p) => p.ticker).filter(Boolean);
   const openMarkets = openMarketTickers.length ? await client.getMarketsByTickers(openMarketTickers) : [];

--- a/src/kalshiLiveSoccer.js
+++ b/src/kalshiLiveSoccer.js
@@ -1,244 +1,357 @@
+const axios = require("axios");
+
+const SOCCER_FEED_URL =
+	"https://api.elections.kalshi.com/v1/live_data/feed?include_events=true&include_markets=true&include_series=true&live_only=false&hydrate=structured_targets&page_size=20&milestone_types=soccer_tournament_multi_leg";
+
 function parseMinute(text) {
-  const s = String(text || '');
-  const m = s.match(/(\d+)(?:\+(\d+))?\s*'?/);
-  if (!m) return null;
-  const base = Number(m[1]);
-  const extra = m[2] ? Number(m[2]) : 0;
-  if (!Number.isFinite(base) || !Number.isFinite(extra)) return null;
-  return base + extra;
+	const s = String(text || "");
+	const m = s.match(/(\d+)(?:\+(\d+))?\s*'?/);
+	if (!m) return null;
+	const base = Number(m[1]);
+	const extra = m[2] ? Number(m[2]) : 0;
+	if (!Number.isFinite(base) || !Number.isFinite(extra)) return null;
+	return base + extra;
 }
 
 function normalizeText(value) {
-  return String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+	return String(value || "")
+		.toLowerCase()
+		.replace(/[^a-z0-9\s]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
 }
 
 function isSoccerCompetitionName(name) {
-  const v = normalizeText(name);
-  if (!v) return false;
+	const v = normalizeText(name);
+	if (!v) return false;
 
-  const negative = [
-    'basketball',
-    'wnba',
-    'nba',
-    'nfl',
-    'baseball',
-    'mlb',
-    'hockey',
-    'nhl',
-    'cricket',
-    'golf',
-    'ufc',
-    'mma',
-    'boxing',
-    'tennis',
-    'esports',
-    'video game',
-    'college football',
-    'pro football',
-  ];
-  if (negative.some((k) => v.includes(k))) return false;
+	const negative = [
+		"basketball",
+		"basquet",
+		"wnba",
+		"nba",
+		"nfl",
+		"baseball",
+		"mlb",
+		"hockey",
+		"nhl",
+		"cricket",
+		"golf",
+		"ufc",
+		"mma",
+		"boxing",
+		"tennis",
+		"esports",
+		"video game",
+		"college football",
+		"pro football",
+		"acb",
+		"darts",
+		"nascar",
+		"ryder cup",
+		"cup series",
+		"extraliga",
+	];
+	if (negative.some((k) => v.includes(k))) return false;
 
-  const positive = [
-    'soccer',
-    'champions league',
-    'europa league',
-    'conference league',
-    'world cup',
-    'fa cup',
-    'copa',
-    'coppa',
-    'cup',
-    'premier league',
-    'saudi pro league',
-    'mls',
-    'serie a',
-    'bundesliga',
-    'la liga',
-    'ligue 1',
-    'eredivisie',
-    'primeira',
-    'superliga',
-    'hnl',
-    'liga',
-    'concacaf',
-    'conmebol',
-    'afc champions',
-    'uefa',
-    'division',
-  ];
-  return positive.some((k) => v.includes(k));
+	const positive = [
+		"soccer",
+		"champions league",
+		"europa league",
+		"conference league",
+		"world cup",
+		"fa cup",
+		"copa",
+		"coppa",
+		"cup",
+		"premier league",
+		"saudi pro league",
+		"mls",
+		"serie a",
+		"bundesliga",
+		"la liga",
+		"ligue 1",
+		"eredivisie",
+		"primeira",
+		"super lig",
+		"superliga",
+		"hnl",
+		"ekstraklasa",
+		"liga portugal",
+		"liga mx",
+		"efl championship",
+		"knvb",
+		"usl championship",
+		"swiss super league",
+		"scottish premiership",
+		"japan j1 league",
+		"thai league 1",
+		"nwsl",
+		"liga",
+		"concacaf",
+		"conmebol",
+		"afc champions",
+		"uefa",
+		"division",
+	];
+	return positive.some((k) => v.includes(k));
+}
+
+function discoverSoccerCompetitionsFromEvents(events) {
+	const competitions = new Set();
+	for (const event of events || []) {
+		const competition =
+			event?.product_metadata?.competition ||
+			event?.product_metadata?.league ||
+			event?.__live?.competition ||
+			null;
+		if (!competition) continue;
+		if (!isSoccerCompetitionName(competition)) continue;
+		competitions.add(String(competition).trim());
+	}
+	return Array.from(competitions).sort((a, b) => a.localeCompare(b));
+}
+
+async function fetchSoccerCompetitionsFromFeed() {
+	const response = await axios.get(SOCCER_FEED_URL, {
+		timeout: 15000,
+		headers: {
+			"User-Agent": "Mozilla/5.0",
+			Accept: "application/json",
+		},
+	});
+	const competitions =
+		response.data?.live_filters_by_sports?.Soccer?.competitions || [];
+	return Array.from(
+		new Set(
+			competitions
+				.map((competition) => String(competition || "").trim())
+				.filter((competition) => isSoccerCompetitionName(competition))
+				.filter(Boolean),
+		),
+	).sort((a, b) => a.localeCompare(b));
+}
+
+async function resolveSoccerCompetitionScope(
+	client,
+	events,
+	competitions,
+	logger,
+) {
+	const hasAllLeagues = (competitions || []).some((x) =>
+		["all", "*"].includes(String(x).trim().toLowerCase()),
+	);
+	if (!hasAllLeagues) return competitions || [];
+
+	const discovered = new Set(discoverSoccerCompetitionsFromEvents(events));
+	try {
+		const feedCompetitions = await fetchSoccerCompetitionsFromFeed();
+		for (const competition of feedCompetitions) discovered.add(competition);
+	} catch (error) {
+		logger?.warn?.(
+			{ err: error.message },
+			"Failed to fetch soccer competitions from Kalshi live feed",
+		);
+	}
+	return Array.from(discovered).sort((a, b) => a.localeCompare(b));
 }
 
 function parseNullableInt(value) {
-  const n = Number(value);
-  if (!Number.isFinite(n)) return null;
-  return Math.trunc(n);
+	const n = Number(value);
+	if (!Number.isFinite(n)) return null;
+	return Math.trunc(n);
 }
 
 function countSignificantEvents(events, eventType) {
-  if (!Array.isArray(events)) return null;
-  let count = 0;
-  let seenAny = false;
-  for (const event of events) {
-    if (!event || typeof event !== 'object') continue;
-    const type = String(event.event_type || event.type || '').toLowerCase();
-    if (!type) continue;
-    seenAny = true;
-    if (type === eventType) count += 1;
-  }
-  return seenAny ? count : null;
+	if (!Array.isArray(events)) return null;
+	let count = 0;
+	let seenAny = false;
+	for (const event of events) {
+		if (!event || typeof event !== "object") continue;
+		const type = String(event.event_type || event.type || "").toLowerCase();
+		if (!type) continue;
+		seenAny = true;
+		if (type === eventType) count += 1;
+	}
+	return seenAny ? count : null;
 }
 
 function parseTeams(title) {
-  const t = String(title || '');
-  const m = t.match(/^(.+?)\s+vs\s+(.+)$/i) || t.match(/^(.+?)\s+at\s+(.+)$/i);
-  if (!m) return { homeTeam: null, awayTeam: null };
-  return { homeTeam: m[1].trim(), awayTeam: m[2].trim() };
+	const t = String(title || "");
+	const m = t.match(/^(.+?)\s+vs\s+(.+)$/i) || t.match(/^(.+?)\s+at\s+(.+)$/i);
+	if (!m) return { homeTeam: null, awayTeam: null };
+	return { homeTeam: m[1].trim(), awayTeam: m[2].trim() };
 }
 
 function milestoneIsLive(details) {
-  const status = String(details?.status || '').toLowerCase();
-  const widget = String(details?.widget_status || '').toLowerCase();
-  const half = String(details?.half || '').toLowerCase();
-  const notLiveStatus = ['closed', 'final', 'finished', 'ended', 'cancelled'];
-  if (notLiveStatus.includes(status) || notLiveStatus.includes(widget) || half === 'ft') return false;
-  if (status === 'open' || status === 'live' || widget === 'live' || widget === 'inprogress') return true;
-  return Boolean(parseMinute(details?.time));
+	const status = String(details?.status || "").toLowerCase();
+	const widget = String(details?.widget_status || "").toLowerCase();
+	const half = String(details?.half || "").toLowerCase();
+	const notLiveStatus = ["closed", "final", "finished", "ended", "cancelled"];
+	if (
+		notLiveStatus.includes(status) ||
+		notLiveStatus.includes(widget) ||
+		half === "ft"
+	)
+		return false;
+	if (
+		status === "open" ||
+		status === "live" ||
+		widget === "live" ||
+		widget === "inprogress"
+	)
+		return true;
+	return Boolean(parseMinute(details?.time));
 }
 
 async function getLiveSoccerEventData(client, competitions) {
-  const nowMs = Date.now();
-  const minimumStartDate = new Date(nowMs - 6 * 3600 * 1000).toISOString();
-  const milestones = [];
-  const hasAllLeagues = (competitions || []).some((x) => ['all', '*'].includes(String(x).trim().toLowerCase()));
+	const nowMs = Date.now();
+	const minimumStartDate = new Date(nowMs - 6 * 3600 * 1000).toISOString();
+	const milestones = [];
+	const hasAllLeagues = (competitions || []).some((x) =>
+		["all", "*"].includes(String(x).trim().toLowerCase()),
+	);
 
-  if (hasAllLeagues) {
-    let cursor = '';
-    let page = 0;
-    do {
-      const res = await client.request('GET', '/milestones', {
-        params: {
-          limit: 500,
-          minimum_start_date: minimumStartDate,
-          cursor,
-        },
-      });
-      milestones.push(...(res.milestones || []));
-      cursor = res.cursor || '';
-      page += 1;
-    } while (cursor && page < 20);
-  } else {
-    for (const competition of competitions) {
-      let cursor = '';
-      let page = 0;
-      do {
-        const res = await client.request('GET', '/milestones', {
-          params: {
-            limit: 500,
-            minimum_start_date: minimumStartDate,
-            competition,
-            cursor,
-          },
-        });
-        milestones.push(...(res.milestones || []));
-        cursor = res.cursor || '';
-        page += 1;
-      } while (cursor && page < 5);
-    }
-  }
+	if (hasAllLeagues) {
+		let cursor = "";
+		let page = 0;
+		do {
+			const res = await client.request("GET", "/milestones", {
+				params: {
+					limit: 500,
+					minimum_start_date: minimumStartDate,
+					cursor,
+				},
+			});
+			milestones.push(...(res.milestones || []));
+			cursor = res.cursor || "";
+			page += 1;
+		} while (cursor && page < 20);
+	} else {
+		for (const competition of competitions) {
+			let cursor = "";
+			let page = 0;
+			do {
+				const res = await client.request("GET", "/milestones", {
+					params: {
+						limit: 500,
+						minimum_start_date: minimumStartDate,
+						competition,
+						cursor,
+					},
+				});
+				milestones.push(...(res.milestones || []));
+				cursor = res.cursor || "";
+				page += 1;
+			} while (cursor && page < 5);
+		}
+	}
 
-  const uniqueById = new Map();
-  for (const m of milestones) uniqueById.set(m.id, m);
-  const uniqueMilestones = Array.from(uniqueById.values());
-  if (!uniqueMilestones.length) return new Map();
+	const uniqueById = new Map();
+	for (const m of milestones) uniqueById.set(m.id, m);
+	const uniqueMilestones = Array.from(uniqueById.values());
+	if (!uniqueMilestones.length) return new Map();
 
-  const ids = uniqueMilestones.map((m) => m.id);
-  const liveDatas = [];
-  const chunkSize = 100;
-  for (let i = 0; i < ids.length; i += chunkSize) {
-    const chunk = ids.slice(i, i + chunkSize);
-    const query = chunk.map((id) => `milestone_ids=${encodeURIComponent(id)}`).join('&');
-    const liveBatch = await client.request('GET', `/live_data/batch?${query}`);
-    liveDatas.push(...(liveBatch.live_datas || []));
-  }
+	const ids = uniqueMilestones.map((m) => m.id);
+	const liveDatas = [];
+	const chunkSize = 100;
+	for (let i = 0; i < ids.length; i += chunkSize) {
+		const chunk = ids.slice(i, i + chunkSize);
+		const query = chunk
+			.map((id) => `milestone_ids=${encodeURIComponent(id)}`)
+			.join("&");
+		const liveBatch = await client.request("GET", `/live_data/batch?${query}`);
+		liveDatas.push(...(liveBatch.live_datas || []));
+	}
 
-  const byMilestoneId = new Map(liveDatas.map((x) => [x.milestone_id, x.details || {}]));
-  const byEventTicker = new Map();
+	const byMilestoneId = new Map(
+		liveDatas.map((x) => [x.milestone_id, x.details || {}]),
+	);
+	const byEventTicker = new Map();
 
-  for (const m of uniqueMilestones) {
-    const details = byMilestoneId.get(m.id) || {};
-    const competitionName = m.details?.league || m.details?.competition || null;
-    if (hasAllLeagues && !isSoccerCompetitionName(competitionName)) {
-      continue;
-    }
-    const isLive = milestoneIsLive(details);
-    const minute = parseMinute(details.time || details.last_play?.description || '');
-    const homeScore = Number.isFinite(Number(details.home_same_game_score)) ? Number(details.home_same_game_score) : null;
-    const awayScore = Number.isFinite(Number(details.away_same_game_score)) ? Number(details.away_same_game_score) : null;
-    const homeRedCards =
-      parseNullableInt(details.home_red_cards) ??
-      parseNullableInt(details.home_red_card_count) ??
-      parseNullableInt(details.home_cards_red) ??
-      countSignificantEvents(details.home_significant_events, 'red_card');
-    const awayRedCards =
-      parseNullableInt(details.away_red_cards) ??
-      parseNullableInt(details.away_red_card_count) ??
-      parseNullableInt(details.away_cards_red) ??
-      countSignificantEvents(details.away_significant_events, 'red_card');
-    const tickers = [...(m.primary_event_tickers || []), ...(m.related_event_tickers || [])].filter((t) => String(t).includes('GAME'));
+	for (const m of uniqueMilestones) {
+		const details = byMilestoneId.get(m.id) || {};
+		const competitionName = m.details?.league || m.details?.competition || null;
+		if (hasAllLeagues && !isSoccerCompetitionName(competitionName)) {
+			continue;
+		}
+		const isLive = milestoneIsLive(details);
+		const minute = parseMinute(
+			details.time || details.last_play?.description || "",
+		);
+		const homeScore = Number.isFinite(Number(details.home_same_game_score))
+			? Number(details.home_same_game_score)
+			: null;
+		const awayScore = Number.isFinite(Number(details.away_same_game_score))
+			? Number(details.away_same_game_score)
+			: null;
+		const homeRedCards =
+			parseNullableInt(details.home_red_cards) ??
+			parseNullableInt(details.home_red_card_count) ??
+			parseNullableInt(details.home_cards_red) ??
+			countSignificantEvents(details.home_significant_events, "red_card");
+		const awayRedCards =
+			parseNullableInt(details.away_red_cards) ??
+			parseNullableInt(details.away_red_card_count) ??
+			parseNullableInt(details.away_cards_red) ??
+			countSignificantEvents(details.away_significant_events, "red_card");
+		const tickers = [
+			...(m.primary_event_tickers || []),
+			...(m.related_event_tickers || []),
+		].filter((t) => String(t).includes("GAME"));
 
-    for (const ticker of tickers) {
-      byEventTicker.set(ticker, {
-        milestoneId: m.id,
-        competition: competitionName,
-        isLive,
-        minute,
-        homeScore,
-        awayScore,
-        homeRedCards,
-        awayRedCards,
-        half: details.half || null,
-        status: details.status || null,
-        statusText: details.status_text || null,
-      });
-    }
-  }
+		for (const ticker of tickers) {
+			byEventTicker.set(ticker, {
+				milestoneId: m.id,
+				competition: competitionName,
+				isLive,
+				minute,
+				homeScore,
+				awayScore,
+				homeRedCards,
+				awayRedCards,
+				half: details.half || null,
+				status: details.status || null,
+				statusText: details.status_text || null,
+			});
+		}
+	}
 
-  return byEventTicker;
+	return byEventTicker;
 }
 
 function attachLiveDataToEvents(events, liveMap) {
-  return events.map((event) => {
-    const live = liveMap.get(event.event_ticker);
-    if (!live) return event;
+	return events.map((event) => {
+		const live = liveMap.get(event.event_ticker);
+		if (!live) return event;
 
-    const { homeTeam, awayTeam } = parseTeams(event.title);
-    return {
-      ...event,
-      __live: {
-        competition: live.competition || event.product_metadata?.competition || null,
-        minute: live.minute,
-        homeScore: live.homeScore,
-        awayScore: live.awayScore,
-        homeRedCards: live.homeRedCards,
-        awayRedCards: live.awayRedCards,
-        homeTeam,
-        awayTeam,
-        isLive: live.isLive,
-        half: live.half,
-        status: live.status,
-        statusText: live.statusText,
-      },
-    };
-  });
+		const { homeTeam, awayTeam } = parseTeams(event.title);
+		return {
+			...event,
+			__live: {
+				competition:
+					live.competition || event.product_metadata?.competition || null,
+				minute: live.minute,
+				homeScore: live.homeScore,
+				awayScore: live.awayScore,
+				homeRedCards: live.homeRedCards,
+				awayRedCards: live.awayRedCards,
+				homeTeam,
+				awayTeam,
+				isLive: live.isLive,
+				half: live.half,
+				status: live.status,
+				statusText: live.statusText,
+			},
+		};
+	});
 }
 
 module.exports = {
-  getLiveSoccerEventData,
-  attachLiveDataToEvents,
-  isSoccerCompetitionName,
+	getLiveSoccerEventData,
+	attachLiveDataToEvents,
+	isSoccerCompetitionName,
+	discoverSoccerCompetitionsFromEvents,
+	fetchSoccerCompetitionsFromFeed,
+	resolveSoccerCompetitionScope,
 };

--- a/src/monitorServer.js
+++ b/src/monitorServer.js
@@ -12,7 +12,11 @@ const { KalshiClient, parseFp } = require('./kalshiClient');
 const { toISODateInTz } = require('./stateStore');
 const { getRuntimeConfig, readOverrides, OVERRIDES_PATH } = require('./runtimeConfig');
 const { eligibleTradeCandidate, extractGameState, isLeagueAllowed } = require('./strategy');
-const { getLiveSoccerEventData, attachLiveDataToEvents } = require('./kalshiLiveSoccer');
+const {
+  getLiveSoccerEventData,
+  attachLiveDataToEvents,
+  resolveSoccerCompetitionScope,
+} = require('./kalshiLiveSoccer');
 
 const app = express();
 app.use(cors());
@@ -653,7 +657,8 @@ app.get('/api/dashboard', requireMonitorAuth, async (_req, res) => {
       openPositions = positionsResp || [];
       settlements = settlementsResp || [];
       events = await client.getOpenEventsWithMarkets();
-      liveSoccerMap = await getLiveSoccerEventData(client, runtime.leagues || []);
+      const liveCompetitionScope = await resolveSoccerCompetitionScope(client, events, runtime.leagues || [], logger);
+      liveSoccerMap = await getLiveSoccerEventData(client, liveCompetitionScope);
       events = attachLiveDataToEvents(events, liveSoccerMap);
     } catch (error) {
       logger.warn({ err: error.message }, 'Dashboard API failed to fetch account data');


### PR DESCRIPTION
## Summary
- replace the incomplete `LEAGUES=ALL` soccer discovery path with Kalshi's own live feed competition list
- fix missing live soccer competitions such as `Super Lig` and `Ekstraklasa` in the bot and dashboard monitor API
- tighten soccer competition classification to avoid false positives from non-soccer competitions returned by the live feed

## What changed
- added `resolveSoccerCompetitionScope()` in `src/kalshiLiveSoccer.js`
  - reads `live_filters_by_sports.Soccer.competitions` from Kalshi's live data feed
  - unions that with event-derived competition names as fallback
- updated `src/index.js` to resolve the soccer competition scope before fetching live soccer milestones
- updated `src/monitorServer.js` to use the same competition scope logic as the bot
- expanded `isSoccerCompetitionName()` to recognize missing soccer competitions like `Super Lig` and `Ekstraklasa`
- filtered feed competition names through the soccer classifier to avoid false positives such as non-soccer leagues

## Validation
- `node --check src/index.js`
- `node --check src/kalshiLiveSoccer.js`
- `node --check src/monitorServer.js`
- live validation against Kalshi data confirmed current live competitions include:
  - `Super Lig`
  - `Ekstraklasa`
  - `Croatia HNL`
  - `Bundesliga 2`
  - `Danish Superliga`

## Notes
- left untracked runtime `logs/` out of this PR
- this change is isolated to the live soccer competition discovery path
