### PR TITLE
Replace openclaw naming with clearer project labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ KALSHI_PRIVATE_KEY_PATH=/absolute/path/to/kalshi-private-key.pem
 KALSHI_WEB_USER_ID=
 KALSHI_WEB_SESSION_COOKIE=
 KALSHI_WEB_CSRF_TOKEN=
-KALSHI_WEB_AUTH_STATE_PATH=./.openclaw/kalshi-web-auth.json
+KALSHI_WEB_AUTH_STATE_PATH=./.kalshi-soccer-bot/kalshi-web-auth.json
 INVESTED_START_DATE=2026-03-01T00:00:00Z
 
 # Bot mode

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ data/*.json
 dashboard/node_modules/
 dashboard/dist/
 dashboard/.angular/
-.openclaw/
-.openclaw/*.json
+.kalshi-soccer-bot/
+.kalshi-soccer-bot/*.json
 
 dashboard/public/runtime-config.js

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flowchart LR
     API[Monitor API<br/>src/monitorServer.js]
     Agent[Trading Agent<br/>src/index.js]
     Kalshi[Kalshi APIs<br/>trade API + live data]
-    WebAuth[Kalshi Web Auth State<br/>.openclaw/kalshi-web-auth.json]
+    WebAuth[Kalshi Web Auth State<br/>.kalshi-soccer-bot/kalshi-web-auth.json]
     State[Persistent State<br/>data/state.json]
     Logs[Action Log<br/>logs/trading-actions.ndjson]
 
@@ -230,7 +230,7 @@ Use this prompt when you want another AI coding agent to get the project running
 
 ```text
 You are setting up and running the project at:
-/absolute/path/to/kalshi-openclaw-trading-bot
+/absolute/path/to/kalshi-soccer-trading-bot
 
 Your job is to get the app running end-to-end without asking me for setup help unless a value below is missing or invalid.
 
@@ -297,7 +297,7 @@ Localhost assumptions:
 - DASHBOARD_API_TOKEN=
 
 Kalshi web invested-capital tracking:
-- KALSHI_WEB_AUTH_STATE_PATH=./.openclaw/kalshi-web-auth.json
+- KALSHI_WEB_AUTH_STATE_PATH=./.kalshi-soccer-bot/kalshi-web-auth.json
 - INVESTED_START_DATE=2026-03-01T00:00:00Z
 
 State and overrides:
@@ -341,7 +341,7 @@ How this Kalshi web auth-state file is obtained:
 - run `npm run kalshi:web-auth`
 - the script opens a browser window to Kalshi
 - log into Kalshi normally as the account owner
-- the script saves the authenticated browser state locally to `.openclaw/kalshi-web-auth.json`
+- the script saves the authenticated browser state locally to `.kalshi-soccer-bot/kalshi-web-auth.json`
 - after that, the monitor API can use that local file to read deposit history without manually copying cookies or CSRF tokens
 
 ## Run (3 terminals)
@@ -450,7 +450,7 @@ npm install
 npm run kalshi:web-auth
 ```
 
-This opens a browser, lets you log into Kalshi normally, and saves local browser auth state to `.openclaw/kalshi-web-auth.json`.
+This opens a browser, lets you log into Kalshi normally, and saves local browser auth state to `.kalshi-soccer-bot/kalshi-web-auth.json`.
 
 After that, restart the monitor API:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kalshi-openclaw-trading-bot",
+  "name": "kalshi-soccer-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kalshi-openclaw-trading-bot",
+      "name": "kalshi-soccer-bot",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kalshi-openclaw-trading-bot",
+  "name": "kalshi-soccer-bot",
   "version": "1.0.0",
   "description": "Kalshi soccer in-play trading bot",
   "main": "src/index.js",

--- a/src/config.js
+++ b/src/config.js
@@ -151,7 +151,7 @@ const config = {
 	kalshiWebCsrfToken: process.env.KALSHI_WEB_CSRF_TOKEN || "",
 	kalshiWebAuthStatePath:
 		process.env.KALSHI_WEB_AUTH_STATE_PATH ||
-		path.resolve(".openclaw/kalshi-web-auth.json"),
+		path.resolve(".kalshi-soccer-bot/kalshi-web-auth.json"),
 	investedStartDate: process.env.INVESTED_START_DATE || "2026-03-01T00:00:00Z",
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ function makeOrderPayload(candidate, balanceUsd, runtime, recoveryState) {
       yes_price_dollars: limitPrice.toFixed(4),
       time_in_force: 'good_till_canceled',
       cancel_order_on_pause: true,
-      client_order_id: `openclaw-${candidate.event.event_ticker}-${Date.now()}`,
+      client_order_id: `kalshi-soccer-bot-${candidate.event.event_ticker}-${Date.now()}`,
     },
     sizing: {
       sizingMode,
@@ -265,7 +265,7 @@ function isRestingOrder(order) {
 
 function parseEventTickerFromClientOrderId(clientOrderId) {
   const text = String(clientOrderId || '');
-  const match = text.match(/^openclaw-(.+)-\d+$/);
+  const match = text.match(/^kalshi-soccer-bot-(.+)-\d+$/);
   return match ? match[1] : null;
 }
 
@@ -288,7 +288,7 @@ function syncRestingOrderState(restingOrders, stateStore, events) {
   for (const order of restingOrders || []) {
     if (!isRestingOrder(order)) continue;
     const clientOrderId = order.client_order_id || order.clientOrderId || '';
-    if (!String(clientOrderId).startsWith('openclaw-')) continue;
+    if (!String(clientOrderId).startsWith('kalshi-soccer-bot-')) continue;
     const marketTicker = order.ticker || order.market_ticker || null;
     const eventTicker =
       order.event_ticker ||


### PR DESCRIPTION
## Summary
- replace legacy `openclaw` naming with clearer `kalshi-soccer-bot` naming
- update the default Kalshi web auth-state folder path and matching docs/examples
- rename the bot client order prefix and package name to match the project purpose

## Testing
- Not run (naming/docs/config only)